### PR TITLE
feat: create performance monitor package structure (#3)

### DIFF
--- a/packages/performance-monitor/.eslintrc.json
+++ b/packages/performance-monitor/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "@typescript-eslint/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es6": true
+  },
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/explicit-function-return-type": "warn",
+    "@typescript-eslint/no-explicit-any": "warn"
+  }
+}

--- a/packages/performance-monitor/jest.config.js
+++ b/packages/performance-monitor/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  testMatch: [
+    '**/__tests__/**/*.test.ts',
+    '**/__tests__/**/*.spec.ts'
+  ],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/**/*.test.ts',
+    '!src/**/*.spec.ts'
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts']
+};

--- a/packages/performance-monitor/package.json
+++ b/packages/performance-monitor/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@mf-examples/performance-monitor",
+  "version": "1.0.0",
+  "description": "Performance monitoring package for Module Federation applications",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "jest",
+    "lint": "eslint src --ext .ts,.tsx"
+  },
+  "keywords": [
+    "module-federation",
+    "performance",
+    "monitoring",
+    "web-vitals",
+    "metrics"
+  ],
+  "author": "MF Examples Team",
+  "license": "MIT",
+  "dependencies": {
+    "web-vitals": "^3.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.14.6",
+    "typescript": "^4.9.5",
+    "jest": "^29.5.0",
+    "@types/jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "eslint": "^8.35.0",
+    "@typescript-eslint/eslint-plugin": "^5.54.0",
+    "@typescript-eslint/parser": "^5.54.0"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/performance-monitor/src/__tests__/setup.ts
+++ b/packages/performance-monitor/src/__tests__/setup.ts
@@ -1,0 +1,25 @@
+/**
+ * Jest setup file for performance monitor tests
+ */
+
+// Mock performance API for tests
+Object.defineProperty(global, 'performance', {
+  writable: true,
+  value: {
+    now: jest.fn(() => Date.now()),
+    mark: jest.fn(),
+    measure: jest.fn(),
+    getEntriesByName: jest.fn(() => []),
+    getEntriesByType: jest.fn(() => []),
+  },
+});
+
+// Mock navigator for web vitals
+Object.defineProperty(global, 'navigator', {
+  writable: true,
+  value: {
+    connection: {
+      effectiveType: '4g',
+    },
+  },
+});

--- a/packages/performance-monitor/src/index.ts
+++ b/packages/performance-monitor/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @mf-examples/performance-monitor
+ *
+ * Performance monitoring package for Module Federation applications
+ */
+
+// Core exports will be added in subsequent PRs
+export * from './types';

--- a/packages/performance-monitor/src/types.ts
+++ b/packages/performance-monitor/src/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Core types for performance monitoring
+ */
+
+export interface PerformanceMetric {
+  name: string;
+  value: number;
+  timestamp: number;
+  tags?: Record<string, string>;
+}
+
+export interface ModuleFederationMetric extends PerformanceMetric {
+  remoteUrl: string;
+  moduleName: string;
+  loadType: 'first' | 'cached';
+}
+
+export interface WebVitalsMetric extends PerformanceMetric {
+  rating: 'good' | 'needs-improvement' | 'poor';
+}
+
+export interface BundleMetric extends PerformanceMetric {
+  bundleName: string;
+  size: number;
+  gzippedSize?: number;
+}
+
+export interface PerformanceReport {
+  timestamp: number;
+  duration: number;
+  metrics: PerformanceMetric[];
+  summary: {
+    totalMetrics: number;
+    avgLoadTime: number;
+    bundleSize: number;
+    webVitalsScore: number;
+  };
+}

--- a/packages/performance-monitor/tsconfig.json
+++ b/packages/performance-monitor/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
- Add @mf-examples/performance-monitor package with TypeScript setup
- Configure Jest for testing with jsdom environment
- Add ESLint configuration for code quality
- Define core TypeScript interfaces for metrics
- Set up build and development scripts