### PR TITLE
feat: implement Module Federation performance tracker (#3)

### DIFF
--- a/packages/performance-monitor/src/ModuleFederationTracker.ts
+++ b/packages/performance-monitor/src/ModuleFederationTracker.ts
@@ -1,0 +1,340 @@
+import { PerformanceMonitor } from './PerformanceMonitor';
+import { ModuleFederationMetric } from './types';
+
+export interface ModuleFederationConfig {
+  trackRemoteLoads: boolean;
+  trackChunkLoads: boolean;
+  trackFailures: boolean;
+  remoteUrls: string[];
+}
+
+export class ModuleFederationTracker {
+  private monitor: PerformanceMonitor;
+  private config: ModuleFederationConfig;
+  private originalFetch: typeof fetch;
+  private originalImport: typeof import;
+  private loadCache = new Set<string>();
+  private pendingLoads = new Map<string, number>();
+
+  constructor(monitor: PerformanceMonitor, config: Partial<ModuleFederationConfig> = {}) {
+    this.monitor = monitor;
+    this.config = {
+      trackRemoteLoads: true,
+      trackChunkLoads: true,
+      trackFailures: true,
+      remoteUrls: [],
+      ...config,
+    };
+
+    this.originalFetch = window.fetch;
+    this.initialize();
+  }
+
+  private initialize(): void {
+    this.interceptFetch();
+    this.interceptDynamicImports();
+    this.setupResourceObserver();
+    this.trackWebpackChunks();
+  }
+
+  private interceptFetch(): void {
+    if (!this.config.trackRemoteLoads) return;
+
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+
+      if (this.isModuleFederationResource(url)) {
+        const startTime = performance.now();
+        this.monitor.mark(`mf_fetch_start_${url}`);
+        this.pendingLoads.set(url, startTime);
+
+        try {
+          const response = await this.originalFetch(input, init);
+          const endTime = performance.now();
+          const duration = endTime - startTime;
+
+          this.monitor.mark(`mf_fetch_end_${url}`);
+          this.monitor.measure(`mf_fetch_${url}`, `mf_fetch_start_${url}`, `mf_fetch_end_${url}`);
+
+          this.recordModuleFederationLoad({
+            name: 'module_federation_fetch',
+            value: duration,
+            timestamp: startTime,
+            remoteUrl: url,
+            moduleName: this.extractModuleName(url),
+            loadType: this.loadCache.has(url) ? 'cached' : 'first',
+            tags: {
+              status: response.status.toString(),
+              success: response.ok ? 'true' : 'false',
+              size: response.headers.get('content-length') || '0',
+            },
+          });
+
+          this.loadCache.add(url);
+          this.pendingLoads.delete(url);
+
+          return response;
+        } catch (error) {
+          const endTime = performance.now();
+          const duration = endTime - startTime;
+
+          if (this.config.trackFailures) {
+            this.recordModuleFederationLoad({
+              name: 'module_federation_fetch_error',
+              value: duration,
+              timestamp: startTime,
+              remoteUrl: url,
+              moduleName: this.extractModuleName(url),
+              loadType: this.loadCache.has(url) ? 'cached' : 'first',
+              tags: {
+                error: (error as Error).message || 'Unknown error',
+                success: 'false',
+              },
+            });
+          }
+
+          this.pendingLoads.delete(url);
+          throw error;
+        }
+      }
+
+      return this.originalFetch(input, init);
+    };
+  }
+
+  private interceptDynamicImports(): void {
+    if (!this.config.trackRemoteLoads || typeof window === 'undefined') return;
+
+    // Intercept webpack's __webpack_require__.f.remotes function if available
+    if (typeof (window as any).__webpack_require__ !== 'undefined') {
+      const webpackRequire = (window as any).__webpack_require__;
+
+      if (webpackRequire.f && webpackRequire.f.remotes) {
+        const originalRemotes = webpackRequire.f.remotes;
+
+        webpackRequire.f.remotes = (chunkId: string, promises: Promise<any>[]) => {
+          const startTime = performance.now();
+          this.monitor.mark(`mf_remote_start_${chunkId}`);
+
+          const result = originalRemotes.call(this, chunkId, promises);
+
+          // Track when promises resolve
+          promises.forEach((promise, index) => {
+            if (promise && typeof promise.then === 'function') {
+              promise.then(() => {
+                const endTime = performance.now();
+                const duration = endTime - startTime;
+
+                this.monitor.mark(`mf_remote_end_${chunkId}_${index}`);
+
+                this.recordModuleFederationLoad({
+                  name: 'module_federation_remote_load',
+                  value: duration,
+                  timestamp: startTime,
+                  remoteUrl: `webpack://${chunkId}`,
+                  moduleName: chunkId,
+                  loadType: this.loadCache.has(chunkId) ? 'cached' : 'first',
+                  tags: {
+                    chunkId,
+                    promiseIndex: index.toString(),
+                  },
+                });
+
+                this.loadCache.add(chunkId);
+              }).catch((error) => {
+                if (this.config.trackFailures) {
+                  const endTime = performance.now();
+                  const duration = endTime - startTime;
+
+                  this.recordModuleFederationLoad({
+                    name: 'module_federation_remote_error',
+                    value: duration,
+                    timestamp: startTime,
+                    remoteUrl: `webpack://${chunkId}`,
+                    moduleName: chunkId,
+                    loadType: this.loadCache.has(chunkId) ? 'cached' : 'first',
+                    tags: {
+                      error: error.message || 'Unknown error',
+                      chunkId,
+                      promiseIndex: index.toString(),
+                    },
+                  });
+                }
+              });
+            }
+          });
+
+          return result;
+        };
+      }
+    }
+  }
+
+  private setupResourceObserver(): void {
+    if (!('PerformanceObserver' in window)) return;
+
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          const resource = entry as PerformanceResourceTiming;
+
+          if (this.isModuleFederationResource(resource.name)) {
+            this.recordModuleFederationLoad({
+              name: 'module_federation_resource',
+              value: resource.duration,
+              timestamp: resource.startTime,
+              remoteUrl: resource.name,
+              moduleName: this.extractModuleName(resource.name),
+              loadType: resource.transferSize === 0 ? 'cached' : 'first',
+              tags: {
+                transferSize: resource.transferSize?.toString() || '0',
+                encodedSize: resource.encodedBodySize?.toString() || '0',
+                decodedSize: resource.decodedBodySize?.toString() || '0',
+                protocol: resource.nextHopProtocol || 'unknown',
+                dns: resource.domainLookupEnd - resource.domainLookupStart,
+                tcp: resource.connectEnd - resource.connectStart,
+                ssl: resource.secureConnectionStart > 0
+                  ? resource.connectEnd - resource.secureConnectionStart
+                  : 0,
+                ttfb: resource.responseStart - resource.requestStart,
+                download: resource.responseEnd - resource.responseStart,
+              } as Record<string, string>,
+            });
+          }
+        }
+      });
+
+      observer.observe({ entryTypes: ['resource'] });
+    } catch (error) {
+      console.warn('Failed to set up resource observer:', error);
+    }
+  }
+
+  private trackWebpackChunks(): void {
+    if (!this.config.trackChunkLoads || typeof window === 'undefined') return;
+
+    // Monitor webpack chunk loading
+    if (typeof (window as any).__webpack_require__ !== 'undefined') {
+      const webpackRequire = (window as any).__webpack_require__;
+
+      // Track chunk loading promises
+      if (webpackRequire.f && webpackRequire.f.j) {
+        const originalJsonp = webpackRequire.f.j;
+
+        webpackRequire.f.j = (chunkId: string, promises: Promise<any>[]) => {
+          const startTime = performance.now();
+          this.monitor.mark(`webpack_chunk_start_${chunkId}`);
+
+          const result = originalJsonp.call(this, chunkId, promises);
+
+          promises.forEach((promise, index) => {
+            if (promise && typeof promise.then === 'function') {
+              promise.then(() => {
+                const endTime = performance.now();
+                const duration = endTime - startTime;
+
+                this.monitor.addMetric({
+                  name: 'webpack_chunk_load',
+                  value: duration,
+                  timestamp: startTime,
+                  tags: {
+                    chunkId,
+                    promiseIndex: index.toString(),
+                    type: 'jsonp',
+                  },
+                });
+              }).catch((error) => {
+                if (this.config.trackFailures) {
+                  const endTime = performance.now();
+                  const duration = endTime - startTime;
+
+                  this.monitor.addMetric({
+                    name: 'webpack_chunk_error',
+                    value: duration,
+                    timestamp: startTime,
+                    tags: {
+                      error: error.message || 'Unknown error',
+                      chunkId,
+                      promiseIndex: index.toString(),
+                      type: 'jsonp',
+                    },
+                  });
+                }
+              });
+            }
+          });
+
+          return result;
+        };
+      }
+    }
+  }
+
+  private isModuleFederationResource(url: string): boolean {
+    if (url.includes('remoteEntry.js')) return true;
+    if (url.includes('mf-manifest.json')) return true;
+
+    return this.config.remoteUrls.some(remoteUrl =>
+      url.includes(remoteUrl) || url.startsWith(remoteUrl)
+    );
+  }
+
+  private extractModuleName(url: string): string {
+    if (url.includes('remoteEntry.js')) {
+      const parts = url.split('/');
+      return parts[parts.length - 2] || 'unknown';
+    }
+
+    // Try to extract from webpack chunk names
+    const chunkMatch = url.match(/\/([^\/]+)\.js$/);
+    if (chunkMatch) {
+      return chunkMatch[1];
+    }
+
+    return 'unknown';
+  }
+
+  private recordModuleFederationLoad(metric: ModuleFederationMetric): void {
+    this.monitor.addMetric(metric);
+  }
+
+  public getModuleFederationMetrics(): ModuleFederationMetric[] {
+    return this.monitor.getMetrics().filter(
+      metric => 'remoteUrl' in metric
+    ) as ModuleFederationMetric[];
+  }
+
+  public getLoadStatistics() {
+    const mfMetrics = this.getModuleFederationMetrics();
+
+    const firstLoads = mfMetrics.filter(m => m.loadType === 'first');
+    const cachedLoads = mfMetrics.filter(m => m.loadType === 'cached');
+    const errors = mfMetrics.filter(m => m.name.includes('error'));
+
+    return {
+      totalLoads: mfMetrics.length,
+      firstLoads: firstLoads.length,
+      cachedLoads: cachedLoads.length,
+      errors: errors.length,
+      avgFirstLoadTime: firstLoads.length > 0
+        ? firstLoads.reduce((sum, m) => sum + m.value, 0) / firstLoads.length
+        : 0,
+      avgCachedLoadTime: cachedLoads.length > 0
+        ? cachedLoads.reduce((sum, m) => sum + m.value, 0) / cachedLoads.length
+        : 0,
+      successRate: mfMetrics.length > 0
+        ? ((mfMetrics.length - errors.length) / mfMetrics.length) * 100
+        : 100,
+    };
+  }
+
+  public destroy(): void {
+    // Restore original fetch
+    if (this.originalFetch) {
+      window.fetch = this.originalFetch;
+    }
+
+    this.loadCache.clear();
+    this.pendingLoads.clear();
+  }
+}

--- a/packages/performance-monitor/src/__tests__/ModuleFederationTracker.test.ts
+++ b/packages/performance-monitor/src/__tests__/ModuleFederationTracker.test.ts
@@ -1,0 +1,197 @@
+import { PerformanceMonitor } from '../PerformanceMonitor';
+import { ModuleFederationTracker } from '../ModuleFederationTracker';
+
+// Mock fetch
+const mockFetch = jest.fn();
+Object.defineProperty(global, 'fetch', {
+  value: mockFetch,
+  writable: true,
+});
+
+describe('ModuleFederationTracker', () => {
+  let monitor: PerformanceMonitor;
+  let tracker: ModuleFederationTracker;
+
+  beforeEach(() => {
+    monitor = new PerformanceMonitor({ enabled: true });
+    tracker = new ModuleFederationTracker(monitor, {
+      remoteUrls: ['http://localhost:8081', 'http://localhost:8082']
+    });
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    tracker.destroy();
+    monitor.destroy();
+  });
+
+  describe('initialization', () => {
+    it('should create tracker instance', () => {
+      expect(tracker).toBeInstanceOf(ModuleFederationTracker);
+    });
+
+    it('should accept custom configuration', () => {
+      const customTracker = new ModuleFederationTracker(monitor, {
+        trackRemoteLoads: false,
+        trackChunkLoads: false,
+      });
+      expect(customTracker).toBeInstanceOf(ModuleFederationTracker);
+      customTracker.destroy();
+    });
+  });
+
+  describe('Module Federation resource detection', () => {
+    it('should identify remote entry files', () => {
+      const isRemoteEntry = (tracker as any).isModuleFederationResource('http://localhost:8081/remoteEntry.js');
+      expect(isRemoteEntry).toBe(true);
+    });
+
+    it('should identify manifest files', () => {
+      const isManifest = (tracker as any).isModuleFederationResource('http://localhost:8081/mf-manifest.json');
+      expect(isManifest).toBe(true);
+    });
+
+    it('should identify configured remote URLs', () => {
+      const isConfiguredRemote = (tracker as any).isModuleFederationResource('http://localhost:8081/some-chunk.js');
+      expect(isConfiguredRemote).toBe(true);
+    });
+
+    it('should not identify regular resources', () => {
+      const isRegular = (tracker as any).isModuleFederationResource('http://example.com/regular.js');
+      expect(isRegular).toBe(false);
+    });
+  });
+
+  describe('module name extraction', () => {
+    it('should extract name from remote entry URL', () => {
+      const moduleName = (tracker as any).extractModuleName('http://localhost:8081/remote/remoteEntry.js');
+      expect(moduleName).toBe('remote');
+    });
+
+    it('should extract name from chunk URL', () => {
+      const moduleName = (tracker as any).extractModuleName('http://localhost:8081/chunk-123.js');
+      expect(moduleName).toBe('chunk-123');
+    });
+
+    it('should return unknown for unrecognized patterns', () => {
+      const moduleName = (tracker as any).extractModuleName('http://localhost:8081/');
+      expect(moduleName).toBe('unknown');
+    });
+  });
+
+  describe('fetch interception', () => {
+    it('should intercept Module Federation fetches', async () => {
+      const mockResponse = new Response('mock content', { status: 200 });
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const performanceMark = jest.spyOn(performance, 'mark');
+      const performanceMeasure = jest.spyOn(performance, 'measure');
+
+      await fetch('http://localhost:8081/remoteEntry.js');
+
+      expect(performanceMark).toHaveBeenCalledWith(expect.stringContaining('mf_fetch_start_'));
+      expect(performanceMark).toHaveBeenCalledWith(expect.stringContaining('mf_fetch_end_'));
+      expect(performanceMeasure).toHaveBeenCalledWith(
+        expect.stringContaining('mf_fetch_'),
+        expect.stringContaining('mf_fetch_start_'),
+        expect.stringContaining('mf_fetch_end_')
+      );
+
+      const mfMetrics = tracker.getModuleFederationMetrics();
+      expect(mfMetrics.length).toBeGreaterThan(0);
+      expect(mfMetrics[0].name).toBe('module_federation_fetch');
+    });
+
+    it('should track fetch errors', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      try {
+        await fetch('http://localhost:8081/remoteEntry.js');
+      } catch (error) {
+        // Expected to throw
+      }
+
+      const mfMetrics = tracker.getModuleFederationMetrics();
+      const errorMetric = mfMetrics.find(m => m.name === 'module_federation_fetch_error');
+      expect(errorMetric).toBeDefined();
+      expect(errorMetric?.tags?.error).toBe('Network error');
+    });
+
+    it('should not intercept non-MF fetches', async () => {
+      const mockResponse = new Response('mock content');
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await fetch('http://example.com/api/data');
+
+      // Should not create MF metrics
+      const mfMetrics = tracker.getModuleFederationMetrics();
+      expect(mfMetrics).toHaveLength(0);
+    });
+
+    it('should track cached vs first loads', async () => {
+      const mockResponse = new Response('mock content', { status: 200 });
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // First load
+      await fetch('http://localhost:8081/remoteEntry.js');
+      // Second load (should be cached)
+      await fetch('http://localhost:8081/remoteEntry.js');
+
+      const mfMetrics = tracker.getModuleFederationMetrics();
+      expect(mfMetrics).toHaveLength(2);
+      expect(mfMetrics[0].loadType).toBe('first');
+      expect(mfMetrics[1].loadType).toBe('cached');
+    });
+  });
+
+  describe('statistics', () => {
+    it('should calculate load statistics', async () => {
+      const mockResponse = new Response('mock content', { status: 200 });
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Perform some loads
+      await fetch('http://localhost:8081/remoteEntry.js');
+      await fetch('http://localhost:8081/remoteEntry.js'); // cached
+      await fetch('http://localhost:8082/remoteEntry.js');
+
+      const stats = tracker.getLoadStatistics();
+      expect(stats.totalLoads).toBe(3);
+      expect(stats.firstLoads).toBe(2);
+      expect(stats.cachedLoads).toBe(1);
+      expect(stats.errors).toBe(0);
+      expect(stats.successRate).toBe(100);
+      expect(stats.avgFirstLoadTime).toBeGreaterThanOrEqual(0);
+      expect(stats.avgCachedLoadTime).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should handle error statistics', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      try {
+        await fetch('http://localhost:8081/remoteEntry.js');
+      } catch (error) {
+        // Expected
+      }
+
+      const stats = tracker.getLoadStatistics();
+      expect(stats.totalLoads).toBe(1);
+      expect(stats.errors).toBe(1);
+      expect(stats.successRate).toBe(0);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should restore original fetch on destroy', () => {
+      const originalFetch = global.fetch;
+      tracker.destroy();
+      expect(global.fetch).toBe(originalFetch);
+    });
+
+    it('should clear internal caches', () => {
+      tracker.destroy();
+      // Internal caches should be cleared (tested indirectly)
+      expect(tracker.getLoadStatistics().totalLoads).toBe(0);
+    });
+  });
+});

--- a/packages/performance-monitor/src/index.ts
+++ b/packages/performance-monitor/src/index.ts
@@ -6,3 +6,4 @@
 
 export * from './types';
 export * from './PerformanceMonitor';
+export * from './ModuleFederationTracker';


### PR DESCRIPTION
- Add ModuleFederationTracker for monitoring MF-specific metrics
- Intercept fetch API to track remote entry and chunk loading
- Monitor webpack's internal module loading mechanisms
- Track first load vs cached load performance differences
- Measure DNS, TCP, SSL, TTFB, and download times for MF resources
- Record webpack chunk loading with JSONP tracking
- Generate detailed statistics including success rates and avg times
- Comprehensive test coverage for all tracking scenarios