### PR TITLE
fix: configure Jest environment for React and performance testing

### DIFF
--- a/packages/performance-monitor/jest.config.js
+++ b/packages/performance-monitor/jest.config.js
@@ -4,15 +4,34 @@ module.exports = {
   roots: ['<rootDir>/src'],
   testMatch: [
     '**/__tests__/**/*.test.ts',
-    '**/__tests__/**/*.spec.ts'
+    '**/__tests__/**/*.test.tsx',
+    '**/__tests__/**/*.spec.ts',
+    '**/__tests__/**/*.spec.tsx'
   ],
   collectCoverageFrom: [
     'src/**/*.ts',
+    'src/**/*.tsx',
     '!src/**/*.d.ts',
     '!src/**/*.test.ts',
-    '!src/**/*.spec.ts'
+    '!src/**/*.test.tsx',
+    '!src/**/*.spec.ts',
+    '!src/**/*.spec.tsx'
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
-  setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts']
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        jsx: 'react-jsx'
+      }
+    }
+  },
+  moduleNameMapping: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
 };

--- a/packages/performance-monitor/src/__tests__/setup.ts
+++ b/packages/performance-monitor/src/__tests__/setup.ts
@@ -2,6 +2,8 @@
  * Jest setup file for performance monitor tests
  */
 
+import '@testing-library/jest-dom';
+
 // Mock performance API for tests
 Object.defineProperty(global, 'performance', {
   writable: true,
@@ -14,12 +16,66 @@ Object.defineProperty(global, 'performance', {
   },
 });
 
+// Mock PerformanceObserver
+const mockPerformanceObserver = jest.fn().mockImplementation((_callback) => ({
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+  takeRecords: jest.fn(() => []),
+}));
+mockPerformanceObserver.supportedEntryTypes = ['resource', 'navigation', 'measure', 'mark'];
+global.PerformanceObserver = mockPerformanceObserver as any;
+
+// Mock window object
+Object.defineProperty(window, 'fetch', {
+  writable: true,
+  value: jest.fn(() => Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: {
+      get: jest.fn(() => '1024'),
+    },
+  })),
+});
+
 // Mock navigator for web vitals
 Object.defineProperty(global, 'navigator', {
   writable: true,
   value: {
     connection: {
       effectiveType: '4g',
+    },
+    userAgent: 'jest',
+  },
+});
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+};
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+// Mock console methods to avoid noise in tests
+const originalError = console.error;
+beforeEach(() => {
+  console.error = jest.fn();
+});
+
+afterEach(() => {
+  console.error = originalError;
+});
+
+// Mock webpack require for Module Federation tests
+Object.defineProperty(window, '__webpack_require__', {
+  writable: true,
+  value: {
+    f: {
+      remotes: jest.fn(),
+      j: jest.fn(),
     },
   },
 });


### PR DESCRIPTION
- Add TSX test pattern matching and JSX support to Jest config
- Configure ts-jest to handle JSX with react-jsx transform
- Enhance test setup with comprehensive mocks:
  - PerformanceObserver with supportedEntryTypes
  - window.fetch for network requests
  - localStorage for persistence
  - __webpack_require__ for Module Federation
- Add @testing-library/jest-dom setup for DOM matchers
- Suppress console noise during tests

Resolves: #30

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>