### PR TITLE
fix: resolve TypeScript exactOptionalPropertyTypes conflicts

### DIFF
--- a/packages/performance-monitor/src/BundleAnalyzer.ts
+++ b/packages/performance-monitor/src/BundleAnalyzer.ts
@@ -107,7 +107,7 @@ export class BundleAnalyzer {
       name: this.extractBundleName(resource.name),
       url: resource.name,
       size: resource.encodedBodySize || resource.transferSize || 0,
-      gzippedSize: resource.transferSize || undefined,
+      gzippedSize: resource.transferSize ? resource.transferSize : undefined,
       loadTime: resource.duration,
       compressionRatio: this.calculateCompressionRatio(
         resource.decodedBodySize || 0,

--- a/packages/performance-monitor/src/ModuleFederationTracker.ts
+++ b/packages/performance-monitor/src/ModuleFederationTracker.ts
@@ -286,7 +286,7 @@ export class ModuleFederationTracker {
 
     // Try to extract from webpack chunk names
     const chunkMatch = url.match(/\/([^\/]+)\.js$/);
-    if (chunkMatch) {
+    if (chunkMatch && chunkMatch[1]) {
       return chunkMatch[1];
     }
 

--- a/packages/performance-monitor/src/PerformanceMonitor.ts
+++ b/packages/performance-monitor/src/PerformanceMonitor.ts
@@ -13,7 +13,7 @@ export class PerformanceMonitor {
   private metrics: PerformanceMetric[] = [];
   private observers: PerformanceObserver[] = [];
   private startTime: number;
-  private reportTimer?: NodeJS.Timeout;
+  private reportTimer: NodeJS.Timeout | undefined;
 
   constructor(config: Partial<PerformanceMonitorConfig> = {}) {
     this.config = {
@@ -91,18 +91,21 @@ export class PerformanceMonitor {
       name: 'dom_content_loaded',
       value: entry.domContentLoadedEventEnd - entry.domContentLoadedEventStart,
       timestamp: entry.domContentLoadedEventEnd,
+      tags: undefined,
     });
 
     this.addMetric({
       name: 'load_complete',
       value: entry.loadEventEnd - entry.loadEventStart,
       timestamp: entry.loadEventEnd,
+      tags: undefined,
     });
 
     this.addMetric({
       name: 'time_to_interactive',
-      value: entry.domInteractive - entry.navigationStart,
+      value: entry.domInteractive - entry.fetchStart,
       timestamp: entry.domInteractive,
+      tags: undefined,
     });
   }
 
@@ -148,7 +151,7 @@ export class PerformanceMonitor {
       name: `mark_${name}`,
       value: performance.now(),
       timestamp: performance.now(),
-      tags,
+      tags: tags || undefined,
     });
   }
 
@@ -164,7 +167,7 @@ export class PerformanceMonitor {
           name,
           value: measure.duration,
           timestamp: measure.startTime,
-          tags: { ...tags, type: 'measure' },
+          tags: tags ? { ...tags, type: 'measure' } : { type: 'measure' },
         });
         return measure.duration;
       }

--- a/packages/performance-monitor/src/PerformanceReporter.ts
+++ b/packages/performance-monitor/src/PerformanceReporter.ts
@@ -41,9 +41,9 @@ export interface ComprehensiveReport extends PerformanceReport {
 
 export class PerformanceReporter {
   private monitor: PerformanceMonitor;
-  private mfTracker?: ModuleFederationTracker;
-  private webVitalsTracker?: WebVitalsTracker;
-  private bundleAnalyzer?: BundleAnalyzer;
+  private mfTracker: ModuleFederationTracker | undefined;
+  private webVitalsTracker: WebVitalsTracker | undefined;
+  private bundleAnalyzer: BundleAnalyzer | undefined;
   private config: ReporterConfig;
   private sessionStartTime: number;
 
@@ -66,9 +66,9 @@ export class PerformanceReporter {
   }
 
   public setTrackers(trackers: {
-    moduleFederation?: ModuleFederationTracker;
-    webVitals?: WebVitalsTracker;
-    bundleAnalyzer?: BundleAnalyzer;
+    moduleFederation: ModuleFederationTracker | undefined;
+    webVitals: WebVitalsTracker | undefined;
+    bundleAnalyzer: BundleAnalyzer | undefined;
   }): void {
     this.mfTracker = trackers.moduleFederation;
     this.webVitalsTracker = trackers.webVitals;

--- a/packages/performance-monitor/src/types.ts
+++ b/packages/performance-monitor/src/types.ts
@@ -6,7 +6,7 @@ export interface PerformanceMetric {
   name: string;
   value: number;
   timestamp: number;
-  tags?: Record<string, string>;
+  tags: Record<string, string> | undefined;
 }
 
 export interface ModuleFederationMetric extends PerformanceMetric {
@@ -22,7 +22,25 @@ export interface WebVitalsMetric extends PerformanceMetric {
 export interface BundleMetric extends PerformanceMetric {
   bundleName: string;
   size: number;
-  gzippedSize?: number;
+  gzippedSize: number | undefined;
+}
+
+export interface BundleInfo {
+  name: string;
+  url: string;
+  size: number;
+  gzippedSize: number | undefined;
+  loadTime: number;
+  compressionRatio: number | undefined;
+  category: 'small' | 'medium' | 'large' | 'huge';
+  type: 'javascript' | 'stylesheet' | 'other' | 'module-federation';
+  cached: boolean;
+}
+
+export interface Trackers {
+  moduleFederation: import('./ModuleFederationTracker').ModuleFederationTracker | undefined;
+  webVitals: import('./WebVitalsTracker').WebVitalsTracker | undefined;
+  bundleAnalyzer: import('./BundleAnalyzer').BundleAnalyzer | undefined;
 }
 
 export interface PerformanceReport {


### PR DESCRIPTION
- Update type definitions to use 'T | undefined' instead of optional properties
- Fix PerformanceMetric, BundleMetric interfaces for strict mode
- Add BundleInfo and Trackers interfaces with proper undefined handling
- Fix PerformanceMonitor timer type declaration
- Fix PerformanceReporter tracker assignments
- Update BundleAnalyzer gzippedSize handling
- Fix ModuleFederationTracker regex match safety
- Add missing tags properties to addMetric calls
- Replace deprecated navigationStart with fetchStart

Resolves: #39