### PR TITLE
fix: resolve React JSX compilation and type issues

### DIFF
--- a/packages/performance-monitor/src/BundleAnalyzer.ts
+++ b/packages/performance-monitor/src/BundleAnalyzer.ts
@@ -1,5 +1,5 @@
 import { PerformanceMonitor } from './PerformanceMonitor';
-import { BundleMetric } from './types';
+import { BundleMetric, BundleInfo } from './types';
 
 export interface BundleAnalyzerConfig {
   trackBundleSizes: boolean;
@@ -13,17 +13,6 @@ export interface BundleAnalyzerConfig {
   };
 }
 
-export interface BundleInfo {
-  name: string;
-  url: string;
-  size: number;
-  gzippedSize?: number;
-  loadTime: number;
-  compressionRatio?: number;
-  category: 'small' | 'medium' | 'large' | 'huge';
-  type: 'javascript' | 'stylesheet' | 'module-federation' | 'other';
-  cached: boolean;
-}
 
 export class BundleAnalyzer {
   private monitor: PerformanceMonitor;

--- a/packages/performance-monitor/src/__tests__/setup.ts
+++ b/packages/performance-monitor/src/__tests__/setup.ts
@@ -22,7 +22,11 @@ const mockPerformanceObserver = jest.fn().mockImplementation((_callback) => ({
   disconnect: jest.fn(),
   takeRecords: jest.fn(() => []),
 }));
-mockPerformanceObserver.supportedEntryTypes = ['resource', 'navigation', 'measure', 'mark'];
+// Add supportedEntryTypes as a static property
+Object.defineProperty(mockPerformanceObserver, 'supportedEntryTypes', {
+  value: ['resource', 'navigation', 'measure', 'mark'],
+  writable: false
+});
 global.PerformanceObserver = mockPerformanceObserver as any;
 
 // Mock window object


### PR DESCRIPTION
- Add JSX support to TypeScript config with react-jsx transform
- Install missing React type dependencies (@types/react, @types/react-dom)
- Install testing library dependencies for React component testing
- Update Jest config to handle TSX files and JSX compilation
- Fix BundleInfo duplicate export by importing from types.ts
- Fix PerformanceObserver mock with proper supportedEntryTypes property
- Add comprehensive test setup with React Testing Library integration

Resolves: #40