### PR TITLE
fix: include metrics in WebVitalsTracker report

### DIFF
--- a/packages/performance-monitor/src/WebVitalsTracker.ts
+++ b/packages/performance-monitor/src/WebVitalsTracker.ts
@@ -194,6 +194,7 @@ export class WebVitalsTracker {
         needsImprovement: 0,
         poor: 0,
       },
+      metrics,
     };
 
     Object.entries(vitals).forEach(([name, value]) => {


### PR DESCRIPTION
- Add unused metrics variable to getWebVitalsReport return object
- Ensures comprehensive reporting includes all collected WebVitals metrics
- Resolves TypeScript unused variable warning

Resolves: #41